### PR TITLE
Add 'Auto' to tcp.rb as well.

### DIFF
--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -290,7 +290,7 @@ module Exploit::Remote::TcpServer
     register_options(
       [
         OptBool.new('SSL',        [ false, 'Negotiate SSL for incoming connections', false]),
-        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'SSL3', ['SSL2', 'SSL3', 'TLS1']]),
+        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'Auto', ['Auto', 'SSL2', 'SSL3', 'TLS1']]),
         OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)']),
         OptAddress.new('SRVHOST', [ true, "The local host to listen on. This must be an address on the local machine or 0.0.0.0", '0.0.0.0' ]),
         OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 8080 ]),


### PR DESCRIPTION
tcp.rb should also offer Auto, otherwise, modules that deal with TCP directly won't get this love. Example module:

```
Module options (auxiliary/gather/android_stock_browser_uxss):

   Name         Current Setting     Required  Description
   ----         ---------------     --------  -----------
   BYPASS_XFO   false               no        Bypass URLs that have X-Frame-Options by using a one-click popup exploit.
   CLOSE_POPUP  true                no        When BYPASS_XFO is enabled, this closes the popup window after exfiltration.
   CUSTOM_JS                        no        A string of javascript to execute in the context of the target URLs.
   REMOTE_JS                        no        A URL to inject into a script tag in the context of the target URLs.
   SRVHOST      192.168.43.169      yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT      8080                yes       The local port to listen on.
   SSL          false               no        Negotiate SSL for incoming connections
   SSLCert                          no        Path to a custom SSL certificate (default is randomly generated)
   SSLVersion   Auto                no        Specify the version of SSL that should be used (accepted: Auto, SSL2, SSL3, TLS1)
   TARGET_URLS  http://example.com  yes       The comma-separated list of URLs to steal.
   URIPATH      c01                 no        The URI to use for this exploit (default is random)
```

tbh I'm not super sure why this module is exposing SSL as an option and not as an advanced option, but that's neither here nor there.
