### PR TITLE
Clean up failure messaging when bad CHOST

### DIFF
--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -276,10 +276,11 @@ def scanner_handle_fatal_errors
   @tl.each {|t| t.kill if t.alive? }
 
   # Show the unique errors triggered by the scan
-  @scan_errors.uniq.each do |emsg|
+  uniq_errors = @scan_errors.uniq
+  uniq_errors.each do |emsg|
     print_error("Fatal: #{emsg}")
   end
-  print_error("Scan terminated due to one or more fatal errors")
+  print_error("Scan terminated due to #{uniq_errors.size} fatal error(s)")
 end
 
 def scanner_progress


### PR DESCRIPTION
This cleans up the failure messaging when CHOST is invalid in #4177.

Before:

```
msf > use auxiliary/scanner/sip/options
msf auxiliary(options) > set CHOST 1.2.3.4
CHOST => 1.2.3.4
msf auxiliary(options) > set RHOSTS 10.4.18.0/24
RHOSTS => 10.4.18.0/24
msf auxiliary(options) > run

[*] Scanned 256 of 256 hosts (100% complete)
[-] Fatal: The source IP (CHOST) value of 1.2.3.4 was not usable
[*] Scan terminated due to one or more fatal errors
[*] Auxiliary module execution completed
```

After:

```
msf > use auxiliary/scanner/sip/options
msf auxiliary(options) > set RHOSTS 10.4.18.0/24
RHOSTS => 10.4.18.0/24
msf auxiliary(options) > set CHOST 1.2.3.4
CHOST => 1.2.3.4
msf auxiliary(options) > run

[-] Fatal: The source IP (CHOST) value of 1.2.3.4 was not usable
[-] Scan terminated due to 1 fatal error(s)
[*] Auxiliary module execution completed

```
