### PR TITLE
Add some randomness to the /tmp filename

### DIFF
--- a/plugins/socket_logger.rb
+++ b/plugins/socket_logger.rb
@@ -42,8 +42,8 @@ class Plugin::SocketLogger < Msf::Plugin
 
 
   def initialize(framework, opts)
-    log_path    = opts['path'] || "/tmp"
-    log_prefix  = opts['prefix'] || "socket_#{Rex::Text.rand_text_alphanumeric(8)}_"
+    log_path    = opts['path'] || Msf::Config.log_directory
+    log_prefix  = opts['prefix'] || "socket_"
 
     super
     @eh = MySocketEventHandler.new(log_path, log_prefix)

--- a/plugins/socket_logger.rb
+++ b/plugins/socket_logger.rb
@@ -43,7 +43,7 @@ class Plugin::SocketLogger < Msf::Plugin
 
   def initialize(framework, opts)
     log_path    = opts['path'] || "/tmp"
-    log_prefix  = opts['prefix'] || "socket_"
+    log_prefix  = opts['prefix'] || "socket_#{Rex::Text.rand_text_alphanumeric(8)}_"
 
     super
     @eh = MySocketEventHandler.new(log_path, log_prefix)


### PR DESCRIPTION
I don't see a way to exploit, but creating predictable /tmp files has bitten me before.

Updated, use ~/.msf4/logs instead.

Touches up rapid7/metasploit-framework#4737

## Verification

- [ ] `load socket_logger`
- [ ] `use auxiliary/scanner/http/http_login`
- [ ] `set rhosts www.metasploit.com`
- [ ] `run`
- [ ] `ls -la /home/USERNAME/.msf4/logs/sock*`
- [ ] See results:

````
-rw-rw-r-- 1 todb todb 5745 Feb  9 16:45 /home/todb/.msf4/logs/socket_0.log
-rw-rw-r-- 1 todb todb 5745 Feb  9 16:45 /home/todb/.msf4/logs/socket_1.log
````