### PR TITLE
Add trailing slash to stageless URI

### DIFF
--- a/lib/msf/core/handler/reverse_http/stageless.rb
+++ b/lib/msf/core/handler/reverse_http/stageless.rb
@@ -27,7 +27,7 @@ module Handler::ReverseHttp::Stageless
   end
 
   def generate_stageless(&block)
-    url = "https://#{datastore['LHOST']}:#{datastore['LPORT']}" + generate_uri_uuid_mode(:connect)
+    url = "https://#{datastore['LHOST']}:#{datastore['LPORT']}#{generate_uri_uuid_mode(:connect)}/"
 
     unless block_given?
       raise ArgumentError, "Stageless generation requires a block argument"


### PR DESCRIPTION
Without the trailing slash, stageless payloads take a nasty turn. For sample output of things not working, see [this comment on the original PR](https://github.com/rapid7/metasploit-framework/pull/5072#issuecomment-89959892).

With this trailing slash added back into the mix, things work properly again.